### PR TITLE
2.3 support

### DIFF
--- a/CentrifugeiOS.podspec
+++ b/CentrifugeiOS.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'CentrifugeiOS/Classes/**/*'
 
-  s.dependency 'SwiftWebSocket', '~> 2.6'
+  s.dependency 'SwiftWebSocket', '~> 2.6.4'
   s.dependency 'IDZSwiftCommonCrypto', '~> 0.8.1'
 end

--- a/CentrifugeiOS.podspec
+++ b/CentrifugeiOS.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = 'CentrifugeiOS/Classes/**/*'
 
   s.dependency 'SwiftWebSocket', '~> 2.6'
-  s.dependency 'IDZSwiftCommonCrypto', '~> 0.7'
+  s.dependency 'IDZSwiftCommonCrypto', '~> 0.8.1'
 end

--- a/CentrifugeiOS.podspec
+++ b/CentrifugeiOS.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'CentrifugeiOS/Classes/**/*'
 
-  s.dependency 'SwiftWebSocket', '~> 2.6.4'
-  s.dependency 'IDZSwiftCommonCrypto', '~> 0.8.1'
+  s.dependency 'SwiftWebSocket', '2.6.4'
+  s.dependency 'IDZSwiftCommonCrypto', '0.8.1'
 end


### PR DESCRIPTION
Now you can use it for xcode 8.0 swift 2.3 ( using legacy in pod build settings)

Before versions in podsec of another 3rd party libraries was different so there was troubles to import in 2.3 swift 
