### PR TITLE
Replace dependency to IDZSwiftCommonCrypto with custom wrapper

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
-github "iosdevzone/IDZSwiftCommonCrypto" ~> 0.10.0
 github "daltoniam/Starscream" ~> 3.0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,1 @@
-github "daltoniam/Starscream" "3.0.4"
-github "daltoniam/common-crypto-spm" "1.1.0"
-github "daltoniam/zlib-spm" "1.1.0"
-github "iosdevzone/IDZSwiftCommonCrypto" "0.10.0"
+github "daltoniam/Starscream" "3.0.5"

--- a/CentrifugeiOS.podspec
+++ b/CentrifugeiOS.podspec
@@ -14,7 +14,9 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.3'
 
-  s.source_files = 'CentrifugeiOS/Classes/**/*'
+  s.source_files = 'CentrifugeiOS/Classes/**/*.{h,m,swift}'
+  s.module_map = 'CentrifugeiOS/Classes/CentrifugeiOS.modulemap'
+  s.private_header_files = 'CentrifugeiOS/Classes/CommonCryptoBridge/CommonCryptoBridge.h'
 
   s.dependency 'Starscream', '~>3.0.4'
 end

--- a/CentrifugeiOS.podspec
+++ b/CentrifugeiOS.podspec
@@ -16,6 +16,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'CentrifugeiOS/Classes/**/*'
 
-  s.dependency 'IDZSwiftCommonCrypto', '~>0.10.0'
   s.dependency 'Starscream', '~>3.0.4'
 end

--- a/CentrifugeiOS.xcodeproj/project.pbxproj
+++ b/CentrifugeiOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BB77FA4F20D01ADB00ED228C /* CommonCryptoBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */; };
+		BB77FA5020D01ADB00ED228C /* CommonCryptoBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D4804CEB200CDF7E00FBBD3D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4804CEA200CDF7E00FBBD3D /* Starscream.framework */; };
 		D492AD2D1FA0AF97003E92FA /* CentrifugeiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D492AD401FA0B00C003E92FA /* Centrifuge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D492AD361FA0B00C003E92FA /* Centrifuge.swift */; };
@@ -15,10 +17,11 @@
 		D492AD441FA0B00C003E92FA /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = D492AD3A1FA0B00C003E92FA /* Protocols.swift */; };
 		D492AD461FA0B00C003E92FA /* CentrifugeClientMessageBuilderImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D492AD3D1FA0B00C003E92FA /* CentrifugeClientMessageBuilderImpl.swift */; };
 		D492AD471FA0B00C003E92FA /* CentrifugoServerMessageParserImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D492AD3E1FA0B00C003E92FA /* CentrifugoServerMessageParserImpl.swift */; };
-		D492AD4A1FA0B639003E92FA /* IDZSwiftCommonCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D492AD481FA0B639003E92FA /* IDZSwiftCommonCrypto.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommonCryptoBridge.m; sourceTree = "<group>"; };
+		BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoBridge.h; sourceTree = "<group>"; };
 		D4804CEA200CDF7E00FBBD3D /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 		D492AD281FA0AF97003E92FA /* CentrifugeiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CentrifugeiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CentrifugeiOS.h; sourceTree = "<group>"; };
@@ -29,7 +32,6 @@
 		D492AD3A1FA0B00C003E92FA /* Protocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		D492AD3D1FA0B00C003E92FA /* CentrifugeClientMessageBuilderImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CentrifugeClientMessageBuilderImpl.swift; sourceTree = "<group>"; };
 		D492AD3E1FA0B00C003E92FA /* CentrifugoServerMessageParserImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CentrifugoServerMessageParserImpl.swift; sourceTree = "<group>"; };
-		D492AD481FA0B639003E92FA /* IDZSwiftCommonCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IDZSwiftCommonCrypto.framework; path = Carthage/Build/iOS/IDZSwiftCommonCrypto.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,7 +39,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D492AD4A1FA0B639003E92FA /* IDZSwiftCommonCrypto.framework in Frameworks */,
 				D4804CEB200CDF7E00FBBD3D /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -45,11 +46,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BB77FA4C20D01ADB00ED228C /* CommonCryptoBridge */ = {
+			isa = PBXGroup;
+			children = (
+				BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */,
+				BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */,
+			);
+			path = CommonCryptoBridge;
+			sourceTree = "<group>";
+		};
 		D492AD1E1FA0AF97003E92FA = {
 			isa = PBXGroup;
 			children = (
 				D4804CEA200CDF7E00FBBD3D /* Starscream.framework */,
-				D492AD481FA0B639003E92FA /* IDZSwiftCommonCrypto.framework */,
 				D492AD2A1FA0AF97003E92FA /* CentrifugeiOS */,
 				D492AD291FA0AF97003E92FA /* Products */,
 			);
@@ -76,6 +85,7 @@
 		D492AD351FA0B00C003E92FA /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				BB77FA4C20D01ADB00ED228C /* CommonCryptoBridge */,
 				D492AD361FA0B00C003E92FA /* Centrifuge.swift */,
 				D492AD371FA0B00C003E92FA /* CentrifugeClientImpl.swift */,
 				D492AD391FA0B00C003E92FA /* Models.swift */,
@@ -102,6 +112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D492AD2D1FA0AF97003E92FA /* CentrifugeiOS.h in Headers */,
+				BB77FA5020D01ADB00ED228C /* CommonCryptoBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BB77FA4F20D01ADB00ED228C /* CommonCryptoBridge.m in Sources */,
 				D492AD431FA0B00C003E92FA /* Models.swift in Sources */,
 				D492AD471FA0B00C003E92FA /* CentrifugoServerMessageParserImpl.swift in Sources */,
 				D492AD411FA0B00C003E92FA /* CentrifugeClientImpl.swift in Sources */,

--- a/CentrifugeiOS.xcodeproj/project.pbxproj
+++ b/CentrifugeiOS.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BB77FA4F20D01ADB00ED228C /* CommonCryptoBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */; };
-		BB77FA5020D01ADB00ED228C /* CommonCryptoBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BB5D1D6820DC109200E98B34 /* CommonCryptoBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = BB5D1D6620DC109200E98B34 /* CommonCryptoBridge.m */; };
+		BBAEA86820DCF09C00A7802C /* CommonCryptoBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = BB5D1D6720DC109200E98B34 /* CommonCryptoBridge.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D4804CEB200CDF7E00FBBD3D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4804CEA200CDF7E00FBBD3D /* Starscream.framework */; };
 		D492AD2D1FA0AF97003E92FA /* CentrifugeiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D492AD401FA0B00C003E92FA /* Centrifuge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D492AD361FA0B00C003E92FA /* Centrifuge.swift */; };
@@ -20,8 +20,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommonCryptoBridge.m; sourceTree = "<group>"; };
-		BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoBridge.h; sourceTree = "<group>"; };
+		BB5D1D4520DC00CB00E98B34 /* CentrifugeiOS.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = CentrifugeiOS.modulemap; sourceTree = "<group>"; };
+		BB5D1D6620DC109200E98B34 /* CommonCryptoBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommonCryptoBridge.m; sourceTree = "<group>"; };
+		BB5D1D6720DC109200E98B34 /* CommonCryptoBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoBridge.h; sourceTree = "<group>"; };
 		D4804CEA200CDF7E00FBBD3D /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 		D492AD281FA0AF97003E92FA /* CentrifugeiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CentrifugeiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CentrifugeiOS.h; sourceTree = "<group>"; };
@@ -46,14 +47,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		BB77FA4C20D01ADB00ED228C /* CommonCryptoBridge */ = {
+		BB5D1D4220DC00CB00E98B34 /* CommonCryptoBridge */ = {
 			isa = PBXGroup;
 			children = (
-				BB77FA4E20D01ADB00ED228C /* CommonCryptoBridge.h */,
-				BB77FA4D20D01ADB00ED228C /* CommonCryptoBridge.m */,
+				BB5D1D6620DC109200E98B34 /* CommonCryptoBridge.m */,
+				BB5D1D6720DC109200E98B34 /* CommonCryptoBridge.h */,
 			);
-			path = CommonCryptoBridge;
-			sourceTree = "<group>";
+			name = CommonCryptoBridge;
+			path = CentrifugeiOS/Classes/CommonCryptoBridge;
+			sourceTree = SOURCE_ROOT;
 		};
 		D492AD1E1FA0AF97003E92FA = {
 			isa = PBXGroup;
@@ -76,7 +78,6 @@
 			isa = PBXGroup;
 			children = (
 				D492AD351FA0B00C003E92FA /* Classes */,
-				D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */,
 				D492AD2C1FA0AF97003E92FA /* Info.plist */,
 			);
 			path = CentrifugeiOS;
@@ -85,7 +86,9 @@
 		D492AD351FA0B00C003E92FA /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				BB77FA4C20D01ADB00ED228C /* CommonCryptoBridge */,
+				BB5D1D4520DC00CB00E98B34 /* CentrifugeiOS.modulemap */,
+				D492AD2B1FA0AF97003E92FA /* CentrifugeiOS.h */,
+				BB5D1D4220DC00CB00E98B34 /* CommonCryptoBridge */,
 				D492AD361FA0B00C003E92FA /* Centrifuge.swift */,
 				D492AD371FA0B00C003E92FA /* CentrifugeClientImpl.swift */,
 				D492AD391FA0B00C003E92FA /* Models.swift */,
@@ -112,7 +115,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D492AD2D1FA0AF97003E92FA /* CentrifugeiOS.h in Headers */,
-				BB77FA5020D01ADB00ED228C /* CommonCryptoBridge.h in Headers */,
+				BBAEA86820DCF09C00A7802C /* CommonCryptoBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,7 +186,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BB77FA4F20D01ADB00ED228C /* CommonCryptoBridge.m in Sources */,
+				BB5D1D6820DC109200E98B34 /* CommonCryptoBridge.m in Sources */,
 				D492AD431FA0B00C003E92FA /* Models.swift in Sources */,
 				D492AD471FA0B00C003E92FA /* CentrifugoServerMessageParserImpl.swift in Sources */,
 				D492AD411FA0B00C003E92FA /* CentrifugeClientImpl.swift in Sources */,
@@ -325,6 +328,7 @@
 				INFOPLIST_FILE = CentrifugeiOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/CentrifugeiOS/Classes/CentrifugeiOS.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.CentrifugeiOS.CentrifugeiOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -349,6 +353,7 @@
 				INFOPLIST_FILE = CentrifugeiOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/CentrifugeiOS/Classes/CentrifugeiOS.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.CentrifugeiOS.CentrifugeiOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/CentrifugeiOS/CentrifugeiOS.h
+++ b/CentrifugeiOS/CentrifugeiOS.h
@@ -15,4 +15,4 @@ FOUNDATION_EXPORT const unsigned char CentrifugeiOSVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <CentrifugeiOS/PublicHeader.h>
 
-
+#import <CentrifugeiOS/CommonCryptoBridge.h>

--- a/CentrifugeiOS/Classes/Centrifuge.swift
+++ b/CentrifugeiOS/Classes/Centrifuge.swift
@@ -6,7 +6,7 @@
 //
 //
 
-import IDZSwiftCommonCrypto
+import Foundation
 
 public let CentrifugeErrorDomain = "com.Centrifuge.error.domain"
 public let CentrifugeWebSocketErrorDomain = "com.Centrifuge.error.domain.websocket"
@@ -31,8 +31,6 @@ public class Centrifuge {
     }
     
     public class func createToken(string: String, key: String) -> String {
-        let hmacs5 = HMAC(algorithm:.sha256, key:key).update(string: string)?.final()
-        let token = hexString(fromArray: hmacs5!)
-        return token
+        return CentrifugeCommonCryptoBridge.hexHMACSHA256(forData: string, withKey: key)
     }
 }

--- a/CentrifugeiOS/Classes/Centrifuge.swift
+++ b/CentrifugeiOS/Classes/Centrifuge.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CentrifugeiOS.CommonCryptoBridge
 
 public let CentrifugeErrorDomain = "com.Centrifuge.error.domain"
 public let CentrifugeWebSocketErrorDomain = "com.Centrifuge.error.domain.websocket"

--- a/CentrifugeiOS/Classes/CentrifugeiOS.h
+++ b/CentrifugeiOS/Classes/CentrifugeiOS.h
@@ -14,5 +14,3 @@ FOUNDATION_EXPORT double CentrifugeiOSVersionNumber;
 FOUNDATION_EXPORT const unsigned char CentrifugeiOSVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <CentrifugeiOS/PublicHeader.h>
-
-#import <CentrifugeiOS/CommonCryptoBridge.h>

--- a/CentrifugeiOS/Classes/CentrifugeiOS.modulemap
+++ b/CentrifugeiOS/Classes/CentrifugeiOS.modulemap
@@ -1,0 +1,10 @@
+framework module CentrifugeiOS {
+    umbrella header "CentrifugeiOS.h"
+
+    export *
+    module * { export * }
+
+    explicit module CommonCryptoBridge {
+        header "CommonCryptoBridge.h"
+    }
+}

--- a/CentrifugeiOS/Classes/CommonCryptoBridge/CommonCryptoBridge.h
+++ b/CentrifugeiOS/Classes/CommonCryptoBridge/CommonCryptoBridge.h
@@ -1,0 +1,15 @@
+//
+//  CommonCryptoBridge.h
+//  CentrifugeiOS
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CentrifugeCommonCryptoBridge : NSObject
+
++ (NSString*)hexHMACSHA256ForData:(NSString*)data withKey:(NSString*)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CentrifugeiOS/Classes/CommonCryptoBridge/CommonCryptoBridge.m
+++ b/CentrifugeiOS/Classes/CommonCryptoBridge/CommonCryptoBridge.m
@@ -1,0 +1,27 @@
+//
+//  CommonCryptoBridge.m
+//  CentrifugeiOS
+
+#import "CommonCryptoBridge.h"
+#import <CommonCrypto/CommonHMAC.h>
+
+@implementation CentrifugeCommonCryptoBridge
+
++ (NSString*)hexHMACSHA256ForData:(NSString*)data withKey:(NSString*)key {
+    const char *dataCharPtr = [data cStringUsingEncoding:NSASCIIStringEncoding];
+    const char *keyCharPtr = [key cStringUsingEncoding:NSASCIIStringEncoding];
+    unsigned char hmac[CC_SHA256_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA256, keyCharPtr, strlen(keyCharPtr), dataCharPtr, strlen(dataCharPtr), hmac);
+    NSData *result = [[NSData alloc] initWithBytes:hmac length:sizeof(hmac)];
+
+    NSUInteger resultLength = [result length];
+    const unsigned char *resultBytes = (const unsigned char *)result.bytes;
+    NSMutableString *hexString = [NSMutableString stringWithCapacity:(resultLength * 2)];
+
+    for (int i = 0; i < resultLength; ++i)
+        [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)resultBytes[i]]];
+
+    return [NSString stringWithString:hexString];
+}
+
+@end

--- a/Example/CentrifugeiOS.xcodeproj/project.pbxproj
+++ b/Example/CentrifugeiOS.xcodeproj/project.pbxproj
@@ -294,13 +294,11 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-CentrifugeiOS_Example/Pods-CentrifugeiOS_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CentrifugeiOS/CentrifugeiOS.framework",
-				"${BUILT_PRODUCTS_DIR}/IDZSwiftCommonCrypto/IDZSwiftCommonCrypto.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CentrifugeiOS.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IDZSwiftCommonCrypto.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -382,13 +380,11 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-CentrifugeiOS_Tests/Pods-CentrifugeiOS_Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CentrifugeiOS/CentrifugeiOS.framework",
-				"${BUILT_PRODUCTS_DIR}/IDZSwiftCommonCrypto/IDZSwiftCommonCrypto.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CentrifugeiOS.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IDZSwiftCommonCrypto.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
I'd like you to consider this PR and would be happy to hear any thoughts on a topic.

Motivation:
IDZSwiftCommonCrypto library uses quite interesting way of wrapping CommonCrypto library involving some build-time tasks, written in a form of script in Swift. This approach works perfectly fine in case when you don't commit Carthage artefacts in your repo (what many developers do by default).
Otherwise you may encounter issues related to the way how IDZSwiftCommonCrypto wraps CommonCrypto, hardcoding the paths to iPhoneOS and iPhoneSimulator SDKs, that makes it non-portable between machines in general.

Solution:
CommonCrypto in this library is used only for one purpose - Generate HMAC digest. I would like you to consider this PR, which removes this dependency, replacing it with small custom wrapper around CommonCrypto in Obj-C. Also I added custom module map with description for CommonCrypto module. This is needed to make framework artefact portable (apps and other libs cannot link to this framework without modulemap provided)

Pros:
+ Less dependencies for a library, faster setup
+ Fix issue for case when library is provided as a ready .framework artefact

Cons:
- In case any other CommonCrypto features needed, another wrapper would be required or other solution

Possible alternatives:
Replace IDZSwiftCommonCrypto with more Swifty and popular https://github.com/krzyzanowskim/CryptoSwift
or some other library which would cover need in HMAC algo and will be more appropriate