### PR TITLE
Private channels

### DIFF
--- a/CentrifugeiOS/Classes/Builder/CentrifugeClientMessageBuilderImpl.swift
+++ b/CentrifugeiOS/Classes/Builder/CentrifugeClientMessageBuilderImpl.swift
@@ -11,6 +11,7 @@ protocol CentrifugeClientMessageBuilder {
     func buildConnectMessage(credentials: CentrifugeCredentials) -> CentrifugeClientMessage
     func buildDisconnectMessage() -> CentrifugeClientMessage
     func buildSubscribeMessageTo(channel: String) -> CentrifugeClientMessage
+    func buildSubscribeMessageToPrivate(channel: String, client: String, sign: String) -> CentrifugeClientMessage
     func buildSubscribeMessageTo(channel: String, lastMessageUUID: String) -> CentrifugeClientMessage
     func buildUnsubscribeMessageFrom(channel: String) -> CentrifugeClientMessage
     func buildPresenceMessage(channel: String) -> CentrifugeClientMessage
@@ -42,6 +43,15 @@ class CentrifugeClientMessageBuilderImpl: CentrifugeClientMessageBuilder {
     
     func buildSubscribeMessageTo(channel: String) -> CentrifugeClientMessage {
         let params = ["channel" : channel]
+        return buildMessage(method: .subscribe, params: params)
+    }
+    
+    func buildSubscribeMessageToPrivate(channel: String, client: String, sign: String) -> CentrifugeClientMessage {
+        let params = [
+            "channel" : channel,
+            "client" : client,
+            "sign" : sign
+        ]
         return buildMessage(method: .subscribe, params: params)
     }
     

--- a/CentrifugeiOS/Classes/Centrifuge.swift
+++ b/CentrifugeiOS/Classes/Centrifuge.swift
@@ -13,6 +13,8 @@ public let CentrifugeErrorDomain = "com.Centrifuge.error.domain"
 public let CentrifugeWebSocketErrorDomain = "com.Centrifuge.error.domain.websocket"
 public let CentrifugeErrorMessageKey = "com.Centrifuge.error.messagekey"
 
+public let CentrifugePrivateChannelPrefix = "$"
+
 public enum CentrifugeErrorCode: Int {
     case CentrifugeMessageWithError
 }

--- a/CentrifugeiOS/Classes/CentrifugeClientImpl.swift
+++ b/CentrifugeiOS/Classes/CentrifugeClientImpl.swift
@@ -55,6 +55,14 @@ class CentrifugeClientImpl: NSObject, CentrifugeClient, WebSocketDelegate {
         send(message: message)
     }
     
+    func subscribe(privateChannel channel: String, client: String, sign: String, delegate: CentrifugeChannelDelegate, completion: @escaping CentrifugeMessageHandler) {
+        let channel = channel.hasPrefix(CentrifugePrivateChannelPrefix) ? channel : CentrifugePrivateChannelPrefix + channel
+        let message = builder.buildSubscribeMessageToPrivate(channel: channel, client: client, sign: sign)
+        subscription[channel] = delegate
+        messageCallbacks[message.uid] = completion
+        send(message: message)
+    }
+    
     func subscribe(toChannel channel: String, delegate: CentrifugeChannelDelegate, lastMessageUID uid: String, completion: @escaping CentrifugeMessageHandler) {
         let message = builder.buildSubscribeMessageTo(channel: channel, lastMessageUUID: uid)
         subscription[channel] = delegate

--- a/CentrifugeiOS/Classes/Protocols.swift
+++ b/CentrifugeiOS/Classes/Protocols.swift
@@ -30,6 +30,12 @@ public protocol CentrifugeClient {
 
     //MARK: Channel related methods
     func subscribe(toChannel: String, delegate: CentrifugeChannelDelegate, completion: @escaping CentrifugeMessageHandler)
+    
+    /// - Parameters:
+    ///   - channel: Channel UUID
+    ///   - client: 'client' field from `connect` response
+    ///   - sign: token from your backend
+    func subscribe(privateChannel channel: String, client: String, sign: String, delegate: CentrifugeChannelDelegate, completion: @escaping CentrifugeMessageHandler)
     func subscribe(toChannel: String, delegate: CentrifugeChannelDelegate, lastMessageUID: String, completion: @escaping CentrifugeMessageHandler)
     
     func publish(toChannel: String, data: [String : Any], completion: @escaping CentrifugeMessageHandler)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Subscribe to channel:
 ```swift
 client.subscribe(toChannel: channel, delegate: delegate) { message, error in }
 ```
+Subscribe to private channel:
+```swift
+client.subscribe(privateChannel: channel, client: clientString, sign: sign, delegate: delegate) { message, error in }
+```
 Publish: 
 ```swift
 client.publish(toChannel: channel, data:  data) { message, error in }


### PR DESCRIPTION
Added method for private channels subscription.
`func subscribe(privateChannel channel: String, client: String, sign: String, delegate: CentrifugeChannelDelegate, completion: @escaping CentrifugeMessageHandler)`

Parameters:
- `channel`: Channel UUID
- `client`: 'client' field from `connect` method response
- `sign`: token from backend